### PR TITLE
Update torchvision pretrained weight usage

### DIFF
--- a/official_quantization/main.py
+++ b/official_quantization/main.py
@@ -2,6 +2,7 @@ import os
 import torch
 import torch.nn as nn
 import torchvision
+from torchvision.models import ResNet18_Weights
 import torchvision.transforms as transforms
 from torch.quantization import QuantStub, DeQuantStub, QConfig
 
@@ -73,7 +74,7 @@ q_backend = "qnnpack"
 qconfig = torch.quantization.get_default_qconfig(q_backend)
 torch.backends.quantized.engine = q_backend
 
-r18_o = torchvision.models.resnet18(True)
+r18_o = torchvision.models.resnet18(weights=ResNet18_Weights.DEFAULT)
 r18_o.eval()
 
 # Do NOT fuse inplaced relu

--- a/post_quant/README.md
+++ b/post_quant/README.md
@@ -5,11 +5,12 @@ Check main.py or as below:
 ```python
 import torch
 import torchvision
+from torchvision.models import ResNet50_Weights
 import torchvision.datasets as datasets
 import torchvision.transforms.transforms as transforms
 from post_quant.fake_quantization import fake_quant, load_fake_quant_model
 
-model = torchvision.models.resnet50(True)
+model = torchvision.models.resnet50(weights=ResNet50_Weights.DEFAULT)
 model.eval()
 
 db = datasets.ImageFolder(
@@ -37,7 +38,9 @@ q_model = fake_quant(model, dataset)
 torch.save(model.state_dict(), 'model.quant') 
 
 # Reload model:
-m = load_fake_quant_model(torchvision.models.resnet50(), 'model.quant')
+m = load_fake_quant_model(
+    torchvision.models.resnet50(weights=None),
+    'model.quant')
 ```
 
 

--- a/post_quant/fusion.py
+++ b/post_quant/fusion.py
@@ -76,6 +76,8 @@ def validate(net, input_, cuda=True):
 
 if __name__ == '__main__':
     import torchvision
-    mbnet = torchvision.models.mobilenet_v2(True)
+    from torchvision.models import MobileNet_V2_Weights
+
+    mbnet = torchvision.models.mobilenet_v2(weights=MobileNet_V2_Weights.DEFAULT)
     mbnet.eval()
     print(validate(mbnet, torch.randn(32, 3, 224, 224), True))

--- a/post_quant/main.py
+++ b/post_quant/main.py
@@ -1,5 +1,6 @@
 import torch
 import torchvision
+from torchvision.models import ResNet101_Weights
 import torchvision.datasets as datasets
 import torchvision.transforms.transforms as transforms
 import sys
@@ -10,7 +11,7 @@ from post_quant.accuracy_test import validate
 
 
 def main(cali_db_path, validation_path):
-    model = torchvision.models.resnet101(True)
+    model = torchvision.models.resnet101(weights=ResNet101_Weights.DEFAULT)
     model.eval()
     if torch.cuda.is_available():
         model.cuda()
@@ -34,7 +35,7 @@ def main(cali_db_path, validation_path):
         pin_memory=True)
     q_model = fake_quant(model, dataset)
     torch.save(q_model.state_dict(), 'model.quant')
-    m = load_fake_quant_model(torchvision.models.resnet101(), 'model.quant')
+    m = load_fake_quant_model(torchvision.models.resnet101(weights=None), 'model.quant')
     m.cuda()
     fuse_module(model)
 


### PR DESCRIPTION
## Summary
- switch the quantization utilities to the modern torchvision weights API for ResNet and MobileNet models
- update the README snippet to import the appropriate weight enums and to show how to load pretrained or randomly initialized models explicitly

## Testing
- Not run (torch/torchvision unavailable in the execution environment and installing them fails because outbound network access is blocked by the proxy)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9cfe67288327bfd567c883bf65d4)