### PR TITLE
Fix kmeans singleton cluster handling

### DIFF
--- a/cluster/kmeans.py
+++ b/cluster/kmeans.py
@@ -50,7 +50,8 @@ def _kmeans_batch(obs: torch.Tensor,
             obs_id_in_cluster_i = obs_center_ids == i
             if obs_id_in_cluster_i.sum() == 0:
                 continue
-            obs_in_cluster = obs.index_select(0, obs_id_in_cluster_i.nonzero().squeeze())
+            obs_in_cluster = obs.index_select(
+                0, obs_id_in_cluster_i.nonzero(as_tuple=False).squeeze(1))
             c = obs_in_cluster.mean(dim=0)
             if norm_center:
                 c /= c.norm()

--- a/cluster/test_kmeans_regression.py
+++ b/cluster/test_kmeans_regression.py
@@ -1,0 +1,19 @@
+import torch
+
+from cluster.kmeans import kmeans, l2_distance
+
+
+def test_kmeans_handles_single_element_cluster():
+    obs = torch.tensor([
+        [0.0, 0.0],
+        [10.0, 10.0],
+        [11.0, 11.0],
+    ])
+
+    torch.manual_seed(0)
+    centers, _ = kmeans(obs, k=2, iter=1)
+
+    assignments = l2_distance(obs, centers).argmin(dim=1)
+    counts = torch.bincount(assignments, minlength=2)
+
+    assert (counts == 1).any()


### PR DESCRIPTION
## Summary
- replace the use of `.nonzero().squeeze()` in the k-means update loop with a shape-stable alternative so singleton clusters can still be indexed safely
- add a regression test that clusters three points, ensuring one centroid receives exactly one sample and that the algorithm completes without crashing

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'torch')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9d2422108327b77b4035356f93f5)